### PR TITLE
RG-107

### DIFF
--- a/src/main/java/spring/graphql/rest/rql/core/RQL.java
+++ b/src/main/java/spring/graphql/rest/rql/core/RQL.java
@@ -25,7 +25,7 @@ public class RQL {
 	}
 
 	public <K> K rqlSingleSelect(SyncQueryFunction<K> syncQueryFunction, Class<K> parentType, String... attributePaths) {
-		return rqlSelect(syncQueryFunction, Collections::singletonList, parentType, attributePaths);
+		return rqlSelect(syncQueryFunction, Collections::singletonList, parentType, true, attributePaths);
 	}
 
 	public <T extends List<K>, K> T rqlSelect(SyncQueryFunction<T> syncQueryFunction, Class<K> parentType, String... attributePaths) {
@@ -33,7 +33,11 @@ public class RQL {
 	}
 
 	public <T, K> T rqlSelect(SyncQueryFunction<T> syncQueryFunction, ValueExtractor<T, K> extractor, Class<K> parentType, String... attributePaths) {
-		return rqlSyncInternal.rqlSelect(syncQueryFunction::execute, extractor, parentType, attributePaths);
+		return rqlSyncInternal.rqlSelect(syncQueryFunction::execute, extractor, parentType, false, attributePaths);
+	}
+
+	public <T, K> T rqlSelect(SyncQueryFunction<T> syncQueryFunction, ValueExtractor<T, K> extractor, Class<K> parentType, boolean isSingle, String... attributePaths) {
+		return rqlSyncInternal.rqlSelect(syncQueryFunction::execute, extractor, parentType, isSingle, attributePaths);
 	}
 
 	public <T extends Page<K>, K> Page<K> asyncRQLSelectPagination(RQLAsyncRestriction restrictedBy, int amount, AsyncQueryFunction<T> asyncQueryFunction, ValueExtractor<T, K> extractor,

--- a/src/main/java/spring/graphql/rest/rql/core/internal/RQLSyncInternal.java
+++ b/src/main/java/spring/graphql/rest/rql/core/internal/RQLSyncInternal.java
@@ -24,9 +24,13 @@ public class RQLSyncInternal {
 	}
 
 	public <T, K> T rqlSelect(QueryFunction<T> queryFunction, ValueExtractor<T, K> extractor, Class<K> parentType, String... attributePaths) {
+		return rqlSelect(queryFunction, extractor, parentType, false, attributePaths);
+	}
+
+	public <T, K> T rqlSelect(QueryFunction<T> queryFunction, ValueExtractor<T, K> extractor, Class<K> parentType, boolean isSingle, String... attributePaths) {
 		List<PropertyNode> propertyNodes = createPropertyNodes(parentType, attributePaths);
 
-		T queryResult = executeBaseQuery(queryFunction, propertyNodes);
+		T queryResult = executeBaseQuery(queryFunction, propertyNodes, isSingle);
 		List<K> queryData = extractor.extract(queryResult);
 
 		rqlInternal.processSubPartitions(propertyNodes, queryData, "");
@@ -35,17 +39,35 @@ public class RQLSyncInternal {
 	}
 
 
-	private <T> T executeBaseQuery(QueryFunction<T> queryFunction, List<PropertyNode> propertyNodes) {
+	private <T> T executeBaseQuery(QueryFunction<T> queryFunction, List<PropertyNode> propertyNodes, boolean isSingle) {
+		// TODO: Check if all requirements are met
+		//  - Only one record
+		//  - Only one OM relation for the parent (and all subsequent relations)
+		//  then just do an eager call since it's more efficient
+		//  ELSE, continue existing method
 		List<PropertyNode> currentPartition = getCurrentValidPartition(propertyNodes, "")
 				.stream().filter(PropertyNode::isXToOne).collect(Collectors.toList());
 		List<String> paths = currentPartition.stream().map(PropertyNode::getGraphPath).collect(Collectors.toList());
+		if (isSingle && meetsEagerRequirements(propertyNodes, "")) {
+			currentPartition = propertyNodes;
+			paths = propertyNodes.stream().map(PropertyNode::getGraphPath).collect(Collectors.toList());
+		}
 
 		EntityGraph graph = paths.isEmpty() ? EntityGraphs.empty() :
 				EntityGraphUtils.fromAttributePaths(EntityGraphType.LOAD, paths.toArray(new String[0]));
+
 		T queryResult = queryFunction.execute(graph);
 
-		propertyNodes.forEach(node -> completeNode(new PropertyNode(), currentPartition, node));
+		List<PropertyNode> finalCurrentPartition = currentPartition;
+		propertyNodes.forEach(node -> completeNode(new PropertyNode(), finalCurrentPartition, node));
 		return queryResult;
+	}
+
+	private boolean meetsEagerRequirements(List<PropertyNode> propertyNodes, String parentPropertyPath) {
+		List<PropertyNode> partition = getCurrentValidPartition(propertyNodes, parentPropertyPath);
+		if (partition.stream().filter(PropertyNode::isOneToMany).count() > 1) return false;
+		if (partition.isEmpty()) return true;
+		return partition.stream().allMatch(node -> meetsEagerRequirements(propertyNodes, node.getGraphPath()));
 	}
 
 }

--- a/src/main/java/spring/graphql/rest/rql/example/service/AccountService.java
+++ b/src/main/java/spring/graphql/rest/rql/example/service/AccountService.java
@@ -60,9 +60,6 @@ public class AccountService {
 				Account.class, attributePaths
 		);
 
-//		Account entity = accountRepository.findById(id, EntityGraphUtility.getEagerEntityGraph(paths))
-//				.orElseThrow(() -> new RuntimeException("Some exception"));
-
 		// Map properties
 		List<String> props = new ArrayList<>();
 		return universalMapper.toAccountDto(entity, new StringBuilder(), propertyNodes, props, "");


### PR DESCRIPTION
Implemented more optimized single-select (specifically for the use-case when there is one one-to-many relation on the parent, and in the subsequent data)
This should maybe be implemented so that it always gets one of the one-to-many relations each time the parent gets called, too complicated for implementation now.